### PR TITLE
Get-SqlPackagePath.ps1: Handle case where C:\Microsoft Visual Studio\ directory does not exist

### DIFF
--- a/extensions/PublishDacPac/PublishDacPacTask/ps_modules/PublishDacPac/public/Get-SqlPackagePath.ps1
+++ b/extensions/PublishDacPac/PublishDacPacTask/ps_modules/PublishDacPac/public/Get-SqlPackagePath.ps1
@@ -65,7 +65,7 @@ function Get-SqlPackagePath {
 
     $SqlPackageExes += Get-Childitem -Path "${env:ProgramFiles(x86)}\Microsoft SQL Server\*\Tools\Binn" -Recurse -Include $ExeName -ErrorAction SilentlyContinue;
 
-    $VsPaths = Resolve-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\*\*\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\";
+    $VsPaths = Resolve-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\*\*\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\" -ErrorAction SilentlyContinue;
     foreach ($VsPath in $VsPaths) {
         $SqlPackageExes += Get-Childitem -Path $VsPath -Recurse -Include $ExeName -ErrorAction SilentlyContinue;
     }


### PR DESCRIPTION
To prevent the following error message:
![image](https://user-images.githubusercontent.com/3524191/104220950-21637500-5438-11eb-8f1f-6c46bb737499.png)