### PR TITLE
Bump RunSqlCmdScripts version to 1.1.9 to include trustServerCertificate

### DIFF
--- a/extensions/RunSqlCmdScripts/RunSqlCmdScriptTask/task.json
+++ b/extensions/RunSqlCmdScripts/RunSqlCmdScriptTask/task.json
@@ -21,7 +21,7 @@
     "version": {
         "Major": "1",
         "Minor": "1",
-        "Patch": "8"
+        "Patch": "9"
     },
     "instanceNameFormat": "Run SQLCMD Script $(SqlCmdSciptPath)",
     "inputs": [

--- a/extensions/RunSqlCmdScripts/RunSqlCmdScriptsInFolderTask/task.json
+++ b/extensions/RunSqlCmdScripts/RunSqlCmdScriptsInFolderTask/task.json
@@ -21,7 +21,7 @@
     "version": {
         "Major": "1",
         "Minor": "1",
-        "Patch": "8"
+        "Patch": "9"
     },
     "instanceNameFormat": "Run SQLCMD Scripts in folder $(SqlCmdSciptFolderPath)",
     "inputs": [

--- a/extensions/RunSqlCmdScripts/vss-extension.json
+++ b/extensions/RunSqlCmdScripts/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "RunSqlCmdScripts",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "name": "Run SQL / SQLCMD Scripts passing multiple SQLCMD variables",
     "publisher": "DrJohnExtensions",
     "description": "Run SQLCMD scripts against your SQL Server database",


### PR DESCRIPTION
Bumps the version to 1.1.9 (please check if it needs to be in any other place) so a new release can be made to marketplace.
Current version on marketplace is 1.1.8 from 2021. 
trustServerCertificate was added in #51 but the version wasn't changed. 